### PR TITLE
Expand/compress visual mode selection with J/K

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -35,7 +35,7 @@ export default function App() {
   const [visualInput, setVisualInput] = useState("");
   const [visualSubmode, setVisualSubmode] = useState("select");
   const [keycount, setKeycount] = useState(0);
-  const [visualLines, setVisualLines] = useState(0);
+  const [visualLines, setVisualLines] = useState(-1);
   const [zoomLevel, setZoomLevel] = useState(100);
 
   const pageRef = useRef(null);

--- a/src/App.js
+++ b/src/App.js
@@ -36,6 +36,7 @@ export default function App() {
   const [visualSubmode, setVisualSubmode] = useState("select");
   const [keycount, setKeycount] = useState(0);
   const [visualLines, setVisualLines] = useState(-1);
+  const [visualAnchor, setVisualAnchor] = useState(-1);
   const [zoomLevel, setZoomLevel] = useState(100);
 
   const pageRef = useRef(null);
@@ -73,6 +74,8 @@ export default function App() {
     setKeycount,
     visualLines,
     setVisualLines,
+    visualAnchor,
+    setVisualAnchor,
     visualSubmode,
     setVisualSubmode,
     zoomLevel,
@@ -227,6 +230,7 @@ export default function App() {
           visualInput={visualInput}
           visualSubmode={visualSubmode}
           visualLines={visualLines}
+          visualAnchor={visualAnchor}
           zoomLevel={zoomLevel}
         />
       </div>

--- a/src/App.js
+++ b/src/App.js
@@ -35,7 +35,7 @@ export default function App() {
   const [visualInput, setVisualInput] = useState("");
   const [visualSubmode, setVisualSubmode] = useState("select");
   const [keycount, setKeycount] = useState(0);
-  const [visualLines, setVisualLines] = useState(-1);
+  const [visualLines, setVisualLines] = useState(0);
   const [visualAnchor, setVisualAnchor] = useState(-1);
   const [zoomLevel, setZoomLevel] = useState(100);
 

--- a/src/components/BrowserSimulator.js
+++ b/src/components/BrowserSimulator.js
@@ -90,6 +90,11 @@ export const BrowserSimulator = forwardRef(
         </span>
       );
     };
+
+    const getVisualLinesCount = (visualAnchor, visualLines) => {
+      return visualAnchor < 0 ? 0 : Math.abs(visualAnchor - visualLines) + 1;
+    };
+
     return (
       <div
         style={{
@@ -324,7 +329,10 @@ export const BrowserSimulator = forwardRef(
                   animation: "pulse 2s ease infinite",
                 }}
               >
-                ▌ Visual — {visualLines} line{visualLines !== 1 ? "s" : ""}{" "}
+                ▌ Visual — {getVisualLinesCount(visualAnchor, visualLines)} line
+                {getVisualLinesCount(visualAnchor, visualLines) !== 1
+                  ? "s"
+                  : ""}{" "}
                 selected
               </div>
             )}

--- a/src/components/BrowserSimulator.js
+++ b/src/components/BrowserSimulator.js
@@ -28,8 +28,8 @@ export const BrowserSimulator = forwardRef(
 
     // Helper to determine if a line index should be highlighted
     const getLineHighlight = (lineIdx) => {
-      if (mode !== MODES.VISUAL || visualLines === 0) return {};
-      if (lineIdx < visualLines) {
+      if (mode !== MODES.VISUAL || visualLines < 0) return {};
+      if (lineIdx === visualLines) {
         return {
           background: "#fb923c22",
           transition: "background 0.1s ease-out",

--- a/src/components/BrowserSimulator.js
+++ b/src/components/BrowserSimulator.js
@@ -24,7 +24,21 @@ export const BrowserSimulator = forwardRef(
     pageRef,
   ) => {
     // Visual mode labels (for 12 content blocks)
-    const visualLabels = ["A", "S", "D", "F", "J", "K", "L", "G", "Q", "W", "E", "R"];
+    // Note: J and K are excluded to avoid conflicts with normal mode shortcuts
+    const visualLabels = [
+      "A",
+      "S",
+      "D",
+      "F",
+      "H",
+      "L",
+      "G",
+      "Z",
+      "Q",
+      "W",
+      "E",
+      "R",
+    ];
 
     // Helper to determine if a line index should be highlighted
     const getLineHighlight = (lineIdx) => {

--- a/src/components/BrowserSimulator.js
+++ b/src/components/BrowserSimulator.js
@@ -17,6 +17,7 @@ export const BrowserSimulator = forwardRef(
       hintInput,
       hintSubmode,
       visualLines,
+      visualAnchor,
       visualInput,
       visualSubmode,
       zoomLevel,

--- a/src/components/BrowserSimulator.js
+++ b/src/components/BrowserSimulator.js
@@ -44,11 +44,25 @@ export const BrowserSimulator = forwardRef(
     // Helper to determine if a line index should be highlighted
     const getLineHighlight = (lineIdx) => {
       if (mode !== MODES.VISUAL || visualLines < 0) return {};
-      if (lineIdx === visualLines) {
-        return {
-          background: "#fb923c22",
-          transition: "background 0.1s ease-out",
-        };
+
+      // If anchor is set, highlight range from anchor to cursor
+      if (visualAnchor >= 0) {
+        const start = Math.min(visualAnchor, visualLines);
+        const end = Math.max(visualAnchor, visualLines);
+        if (lineIdx >= start && lineIdx <= end) {
+          return {
+            background: "#fb923c22",
+            transition: "background 0.1s ease-out",
+          };
+        }
+      } else {
+        // No anchor set, only highlight the cursor line
+        if (lineIdx === visualLines) {
+          return {
+            background: "#fb923c22",
+            transition: "background 0.1s ease-out",
+          };
+        }
       }
       return {};
     };

--- a/src/hooks/useKeyboardHandler.js
+++ b/src/hooks/useKeyboardHandler.js
@@ -76,7 +76,7 @@ export function useKeyboardHandler({
         setVisualInput("");
       }
       if (m === MODES.VISUAL) {
-        setVisualLines(0);
+        setVisualLines(-1);
         setVisualSubmode("select");
       }
     },
@@ -234,7 +234,7 @@ export function useKeyboardHandler({
             // User typed a valid label
             const ni = visualInput + charUpper;
             setVisualInput(ni);
-            setVisualLines(labelIdx + 1);
+            setVisualLines(labelIdx);
 
             if (
               cur.type === "inMode" &&

--- a/src/hooks/useKeyboardHandler.js
+++ b/src/hooks/useKeyboardHandler.js
@@ -236,6 +236,32 @@ export function useKeyboardHandler({
           return;
         }
 
+        // Visual mode: J/K to expand selection
+        if (e.key === "j") {
+          const currentLine = visualLines;
+          if (currentLine >= 0 && currentLine < 11) {
+            // Set anchor if not set
+            if (visualAnchor < 0) {
+              setVisualAnchor(currentLine);
+            }
+            const newLine = currentLine + 1;
+            setVisualLines(newLine);
+          }
+          return;
+        }
+        if (e.key === "k") {
+          const currentLine = visualLines;
+          if (currentLine > 0) {
+            // Set anchor if not set
+            if (visualAnchor < 0) {
+              setVisualAnchor(currentLine);
+            }
+            const newLine = currentLine - 1;
+            setVisualLines(newLine);
+          }
+          return;
+        }
+
         // Visual mode: type label to select
         if (e.key.length === 1) {
           const visualLabels = [

--- a/src/hooks/useKeyboardHandler.js
+++ b/src/hooks/useKeyboardHandler.js
@@ -21,6 +21,8 @@ export function useKeyboardHandler({
   setKeycount,
   visualLines,
   setVisualLines,
+  visualAnchor,
+  setVisualAnchor,
   visualSubmode,
   setVisualSubmode,
   zoomLevel,
@@ -77,10 +79,20 @@ export function useKeyboardHandler({
       }
       if (m === MODES.VISUAL) {
         setVisualLines(-1);
+        setVisualAnchor(-1);
         setVisualSubmode("select");
       }
     },
-    [setMode, setCmdInput, setHintInput, setHintSubmode, setVisualInput, setVisualLines, setVisualSubmode],
+    [
+      setMode,
+      setCmdInput,
+      setHintInput,
+      setHintSubmode,
+      setVisualInput,
+      setVisualLines,
+      setVisualAnchor,
+      setVisualSubmode,
+    ],
   );
 
   useEffect(() => {
@@ -247,6 +259,7 @@ export function useKeyboardHandler({
             // User typed a valid label
             const ni = visualInput + charUpper;
             setVisualInput(ni);
+            setVisualAnchor(labelIdx);
             setVisualLines(labelIdx);
 
             if (
@@ -557,11 +570,14 @@ export function useKeyboardHandler({
     setHintSubmode,
     setSequence,
     setVisualLines,
+    setVisualAnchor,
     setVisualSubmode,
     setZoomLevel,
     setKeycount,
     keycount,
     zoomLevel,
+    visualAnchor,
+    visualLines,
     currentChapterIdx,
     currentExerciseIdx,
     setExerciseIdx,

--- a/src/hooks/useKeyboardHandler.js
+++ b/src/hooks/useKeyboardHandler.js
@@ -226,7 +226,20 @@ export function useKeyboardHandler({
 
         // Visual mode: type label to select
         if (e.key.length === 1) {
-          const visualLabels = ["A", "S", "D", "F", "J", "K", "L", "G", "Q", "W", "E", "R"];
+          const visualLabels = [
+            "A",
+            "S",
+            "D",
+            "F",
+            "H",
+            "L",
+            "G",
+            "Z",
+            "Q",
+            "W",
+            "E",
+            "R",
+          ];
           const charUpper = e.key.toUpperCase();
           const labelIdx = visualLabels.indexOf(charUpper);
 


### PR DESCRIPTION
Improve visual mode by:
- Removing J and K from line's labels
- Pressing a label's key only selects that line, not all lines from the top up to the selected line (visual anchor)
- Selection can be expanded/compressed by pressing J/K

fixes #7, fixes #8 